### PR TITLE
fix(version): verdaccio-ldap example use Verdaccio 4.2.2

### DIFF
--- a/ldap-verdaccio/readme.md
+++ b/ldap-verdaccio/readme.md
@@ -36,12 +36,18 @@ To run the containers, run the following command in this folder, it should start
 ➜ docker-compose up --force-recreate --build
 
 Building verdaccio
-Step 1/2 : FROM verdaccio/verdaccio
- ---> 5375f8604262
-Step 2/2 : RUN npm i && npm install verdaccio-ldap
+Step 1/4 : FROM verdaccio/verdaccio:4.2.2
+ ---> 0d58a1eae16d
+Step 2/4 : USER root
  ---> Using cache
- ---> d89640f08005
-Successfully built d89640f08005
+ ---> fb3300bf15cc
+Step 3/4 : RUN npm i && npm i verdaccio-ldap
+ ---> Using cache
+ ---> 97701fa53b43
+Step 4/4 : USER verdaccio
+ ---> Using cache
+ ---> fd5ddaa03d8f
+Successfully built fd5ddaa03d8f
 Successfully tagged ldap-verdaccio_verdaccio:latest
 Recreating verdaccio-ldap-1 ... done
 Recreating openldap         ... done
@@ -49,8 +55,9 @@ Recreating ldap-verdaccio_openldap-seed_1 ... done
 Recreating openldap-admin                 ... done
 Attaching to verdaccio-ldap-1, openldap, ldap-verdaccio_openldap-seed_1, openldap-admin
 verdaccio-ldap-1  |  warn --- config file  - /verdaccio/conf/config.yaml
+verdaccio-ldap-1  |  warn --- Plugin successfully loaded: verdaccio-ldap
+verdaccio-ldap-1  |  warn --- http address - http://0.0.0.0:4873/ - verdaccio/4.2.2
 openldap          | *** CONTAINER_LOG_LEVEL = 3 (info)
-verdaccio-ldap-1  |  warn --- Plugin successfully loaded: ldap
 openldap          | *** Search service in CONTAINER_SERVICE_DIR = /container/service :
 openldap          | *** link /container/service/:ssl-tools/startup.sh to /container/run/startup/:ssl-tools
 openldap          | *** link /container/service/slapd/startup.sh to /container/run/startup/slapd
@@ -58,8 +65,8 @@ openldap          | *** link /container/service/slapd/process.sh to /container/r
 openldap          | *** Set environment for startup files
 openldap          | *** Environment files will be proccessed in this order : 
 openldap          | Caution: previously defined variables will not be overriden.
-openldap          | /container/environment/99-default/default.startup.yaml
 openldap          | /container/environment/99-default/default.yaml
+openldap          | /container/environment/99-default/default.startup.yaml
 ``` 
 
 To stop all containers
@@ -77,6 +84,3 @@ marpontes: pass
 zach: pass
 leonardo: pass
 ```
-
-
-

--- a/ldap-verdaccio/verdaccio-ldap/Dockerfile
+++ b/ldap-verdaccio/verdaccio-ldap/Dockerfile
@@ -1,3 +1,4 @@
-FROM verdaccio/verdaccio:3
-
-RUN npm i && npm install verdaccio-ldap
+FROM verdaccio/verdaccio:4.2.2
+USER root
+RUN npm i && npm i verdaccio-ldap
+USER verdaccio


### PR DESCRIPTION
The `build` command was failing making impossible to start the verdaccio.

I upgraded the example to use the latest `4.2.2` version, tested.